### PR TITLE
matplotlibにおけるRuntimeWarningの解消

### DIFF
--- a/libs/auc_analysis.py
+++ b/libs/auc_analysis.py
@@ -200,6 +200,7 @@ def summary_analysis_binary(miss_summary_file, summary_file, roc_fig,
     plt.title('ROC curve')
     plt.legend(loc="lower right")
     plt.savefig(roc_fig)
+    plt.clf()
     return
 
 
@@ -259,3 +260,4 @@ def summary_analysis_regression(miss_summary_file, summary_file, fig_file):
     plt.ylabel('Predict Value')
     plt.title('Prediction')
     plt.savefig(fig_file)
+    plt.clf()

--- a/libs/auc_analysis.py
+++ b/libs/auc_analysis.py
@@ -200,7 +200,7 @@ def summary_analysis_binary(miss_summary_file, summary_file, roc_fig,
     plt.title('ROC curve')
     plt.legend(loc="lower right")
     plt.savefig(roc_fig)
-    plt.clf()
+    plt.close()
     return
 
 
@@ -260,4 +260,4 @@ def summary_analysis_regression(miss_summary_file, summary_file, fig_file):
     plt.ylabel('Predict Value')
     plt.title('Prediction')
     plt.savefig(fig_file)
-    plt.clf()
+    plt.close()

--- a/libs/learning.py
+++ b/libs/learning.py
@@ -129,5 +129,5 @@ def plot_hist(history, history_folder, metrics, idx):
     axR.legend(['train', 'test'], loc='upper left')
 
     fig.savefig(os.path.join(history_folder, history_file))
-    plt.clf()
+    plt.close()
     return


### PR DESCRIPTION
**概要**
グラフを20個以上同時に開いた状態になる可能性があり、20個以上開いた場合にメモリ消費が多くなるというWarningが出ていた。
グラフを20個以上同時に開く必要はなく、メモリ消費も抑えられるため修正。

**修正内容**
グラフを画像として保存したあとグラフをクリアする。